### PR TITLE
Minor update to reable correct microscope name in the filesstatisticsdb

### DIFF
--- a/src/omerofrontend/image_funcs.py
+++ b/src/omerofrontend/image_funcs.py
@@ -251,6 +251,7 @@ def mapping(microscope):
                      'LSM 710, Axio Examiner': 'LSM 710',
                      'LSM 700, AxioObserver': 'LSM 700',
                      'Celldiscoverer 7':'CD7',
+                     '4652000027-1': 'CD7',
                      'Elyra 7 DUOLINK':'Elyra 7',
                      'Axio Imager.Z2':'Imager',
                      'Axio Observer.Z1 / 7':'Observer',

--- a/src/omerofrontend/middle_ware.py
+++ b/src/omerofrontend/middle_ware.py
@@ -165,7 +165,6 @@ class MiddleWare:
         self._temp_file_handler._delete_user_upload_dir(username)
         
     def _register_in_database(self, scope, username, groupname, import_time, fileData):
-        scope = None
         time_stamp = datetime.datetime.today().strftime(conf.DATE_TIME_FMT)
 
         groupname = str(groupname) if groupname else "Unknown Group"


### PR DESCRIPTION
Literally a couple of line of code, **should** not break anything:
- Remove the definition of microscope name to grab it from the function (microcscope=None). Should solve the undefined name in the filestatistics
- Add the CD7 new name (after the software update)

