### PR TITLE
Add a cronjob to compress the file statistics data

### DIFF
--- a/buildfiles/cron_imports_rollup.yaml
+++ b/buildfiles/cron_imports_rollup.yaml
@@ -1,0 +1,79 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: imports-rollup
+  namespace: core-omero-test
+spec:
+  # Run 15 min after the server-restart CronJob.
+  schedule: "15 6 * * 1-5"
+  timeZone: Europe/Stockholm
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: psql-rollup
+              image: postgres:15
+              env:
+                - name: PGHOST
+                  valueFrom:
+                    secretKeyRef:
+                      name: omero-db-credentials
+                      key: host
+                - name: PGPORT
+                  valueFrom:
+                    secretKeyRef:
+                      name: omero-db-credentials
+                      key: port
+                - name: PGDATABASE
+                  valueFrom:
+                    secretKeyRef:
+                      name: omero-db-credentials
+                      key: database
+                - name: PGUSER
+                  valueFrom:
+                    secretKeyRef:
+                      name: omero-db-credentials
+                      key: username
+                - name: PGPASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: omero-db-credentials
+                      key: password
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  psql -v ON_ERROR_STOP=1 <<'ENDSQL'
+                  -- Aggregate the previous calendar day, then compact those rows.
+                  -- All three CTEs run in a single transaction against the same
+                  -- snapshot, so the DELETE and INSERT are always consistent.
+                  WITH agg AS (
+                      SELECT
+                          DATE(time)::timestamp                        AS agg_time,
+                          username,
+                          groupname,
+                          scope,
+                          SUM(file_count)::int                        AS file_count,
+                          SUM(total_file_size_mb)::double precision    AS total_file_size_mb,
+                          SUM(import_time_s)::double precision         AS import_time_s
+                      FROM imports
+                      WHERE time >= (CURRENT_DATE - 1)::timestamp
+                        AND time  <  CURRENT_DATE::timestamp
+                      GROUP BY DATE(time), username, groupname, scope
+                  ),
+                  del AS (
+                      DELETE FROM imports
+                      WHERE time >= (CURRENT_DATE - 1)::timestamp
+                        AND time  <  CURRENT_DATE::timestamp
+                  )
+                  INSERT INTO imports
+                      (time, username, groupname, scope, file_count, total_file_size_mb, import_time_s)
+                  SELECT agg_time, username, groupname, scope, file_count, total_file_size_mb, import_time_s
+                  FROM agg;
+                  ENDSQL
+                  # See buildfiles/secret_db_credentials.yaml to create the Secret.

--- a/buildfiles/secret_db_credentials.yaml
+++ b/buildfiles/secret_db_credentials.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: omero-db-credentials
+  # Duplicate and update namespace for core-omero-test as needed.
+  namespace: core-omero-dev
+type: Opaque
+# stringData lets you paste plain-text values directly in the
+# OpenShift web-console YAML editor — no base64 needed.
+# OpenShift will encode the values automatically on save.
+stringData:
+  host: "postgres-service-name"   # replace with the postgres Service name in your namespace
+  port: "5432"
+  database: "omerofilestats"
+  username: "gu_cci_postgres"
+  password: "REPLACE_ME"


### PR DESCRIPTION
Add a cronjob to compress the file statistics data in the database. This will help to reduce the size of the database and improve  performance when querying file statistics.

Right now, each image generate an entry.
This job will pool so that all the entry of a microscope by day and by user is compressed in one entry.

On branch feat/filestatistic_compression
Changes to be committed:
    new file:   buildfiles/cron_imports_rollup.yaml
    new file:   buildfiles/secret_db_credentials.yaml